### PR TITLE
Fix Bug in bf.Unique

### DIFF
--- a/bf/bf.go
+++ b/bf/bf.go
@@ -294,6 +294,7 @@ func uniqueRec(vars ...variable) Formula {
 	sqrt := math.Sqrt(float64(nbVars))
 	nbLines := int(sqrt + 0.5)
 	lines := make([]variable, nbLines)
+	linesF := make([][]Formula, nbLines)
 	allNames := make([]string, len(vars))
 	for i := range vars {
 		allNames[i] = vars[i].name
@@ -301,17 +302,27 @@ func uniqueRec(vars ...variable) Formula {
 	fullName := strings.Join(allNames, "-")
 	for i := range lines {
 		lines[i] = dummyVar(fmt.Sprintf("line-%d-%s", i, fullName))
+		linesF[i] = []Formula{}
 	}
 	nbCols := int(math.Ceil(sqrt))
 	cols := make([]variable, nbCols)
+	colsF := make([][]Formula, nbCols)
 	for i := range cols {
 		cols[i] = dummyVar(fmt.Sprintf("col-%d-%s", i, fullName))
+		colsF[i] = []Formula{}
 	}
 	res := make([]Formula, 0, 2*nbVars+1)
 	for i, v := range vars {
-		res = append(res, Or(Not(v), lines[i/nbCols]))
-		res = append(res, Or(Not(v), cols[i%nbCols]))
+		linesF[i/nbCols] = append(linesF[i/nbCols], v)
+		colsF[i%nbCols] = append(colsF[i%nbCols], v)
 	}
+	for i := range lines {
+		res = append(res, Xor(Not(lines[i]), Or(linesF[i]...)))
+	}
+	for i := range cols {
+		res = append(res, Xor(Not(cols[i]), Or(colsF[i]...)))
+	}
+
 	res = append(res, uniqueRec(lines...))
 	res = append(res, uniqueRec(cols...))
 	return And(res...)

--- a/bf/bf.go
+++ b/bf/bf.go
@@ -317,10 +317,10 @@ func uniqueRec(vars ...variable) Formula {
 		colsF[i%nbCols] = append(colsF[i%nbCols], v)
 	}
 	for i := range lines {
-		res = append(res, Xor(Not(lines[i]), Or(linesF[i]...)))
+		res = append(res, Eq(lines[i], Or(linesF[i]...)))
 	}
 	for i := range cols {
-		res = append(res, Xor(Not(cols[i]), Or(colsF[i]...)))
+		res = append(res, Eq(cols[i], Or(colsF[i]...)))
 	}
 
 	res = append(res, uniqueRec(lines...))

--- a/bf/bf_test.go
+++ b/bf/bf_test.go
@@ -29,6 +29,21 @@ func TestUnique(t *testing.T) {
 	}
 }
 
+func TestUniqueAtLeastOne(t *testing.T) {
+	x := make([]string, 12)
+	xF := make([]Formula, len(x))
+	for i := 0; i < len(x); i++ {
+		x[i] = fmt.Sprintf("x%d", i)
+		xF[i] = Var(x[i])
+	}
+
+	f := And(Not(Or(xF...)), Unique(x...))
+	model := Solve(f)
+	if model != nil {
+		t.Errorf("problem is declared satisfiable:\n%+v", model)
+	}
+}
+
 func TestString(t *testing.T) {
 	f := And(Or(Var("a"), Not(Var("b"))), Not(Var("c")))
 	const expected = "and(or(a, not(b)), not(c))"


### PR DESCRIPTION
There was a bug where `bf.Unique` could be true with none of the underlying variables being true.

The `lines[i]` (`cols[i]`) variables were allowed to be True even if none of the variables in their line (col) were. See the test.

Worth noting: I think there may still be bugs in this function. I have problems which go away when I set the threshold to use uniqueSmall to a large value. I wasn't able to get a simple repro of this though.