### PR TITLE
Fix bug in bf NNF -> CNF conversion

### DIFF
--- a/bf/bf_test.go
+++ b/bf/bf_test.go
@@ -228,3 +228,32 @@ func TestCnfFromNnf(t *testing.T) {
 		t.Errorf("Model check failed")
 	}
 }
+
+func TestReproduceInvalidSolutionBug2(t *testing.T) {
+	f := And(And(And(Or(Not(And(Or(Not(And(Var("a"), Var("e"))),
+		Not(And(Var("b"), Var("g")))), Or(And(Var("a"), Var("e")), And(Var("b"),
+			Var("g"))))), Var("i")), Or(And(Or(Not(And(Var("a"), Var("e"))),
+				Not(And(Var("b"), Var("g")))), Or(And(Var("a"), Var("e")), And(Var("b"),
+					Var("g")))), Not(Var("i")))), And(Or(Not(And(Or(Not(And(Var("c"),
+						Var("e"))), Not(And(Var("d"), Var("g")))), Or(And(Var("c"), Var("e")),
+							And(Var("d"), Var("g"))))), Var("k")), Or(And(Or(Not(And(Var("c"),
+								Var("e"))), Not(And(Var("d"), Var("g")))), Or(And(Var("c"), Var("e")),
+									And(Var("d"), Var("g")))), Not(Var("k")))),
+		And(Or(Not(And(Or(Not(And(Var("a"), Var("f"))), Not(And(Var("b"),
+			Var("h")))), Or(And(Var("a"), Var("f")), And(Var("b"), Var("h"))))),
+			Var("j")), Or(And(Or(Not(And(Var("a"), Var("f"))), Not(And(Var("b"),
+				Var("h")))), Or(And(Var("a"), Var("f")), And(Var("b"), Var("h")))),
+				Not(Var("j")))), And(Or(Not(And(Or(Not(And(Var("c"), Var("f"))),
+					Not(And(Var("d"), Var("h")))), Or(And(Var("c"), Var("f")), And(Var("d"),
+						Var("h"))))), Var("l")), Or(And(Or(Not(And(Var("c"), Var("f"))),
+							Not(And(Var("d"), Var("h")))), Or(And(Var("c"), Var("f")), And(Var("d"),
+								Var("h")))), Not(Var("l"))))), And(And(Not(Var("a")), Not(Var("b"))),
+									And(Var("i"), Not(Var("j")), Not(Var("k")), Var("l"))))
+	model := Solve(f)
+	if model == nil {
+		t.Errorf("Failed to solve; f:\n%s", f)
+	}
+	if !f.Eval(model) {
+		t.Errorf("Model check failed")
+	}
+}

--- a/bf/bf_test.go
+++ b/bf/bf_test.go
@@ -211,3 +211,20 @@ func BenchmarkUnique1000(b *testing.B) {
 		benchmarkUnique(1000)
 	}
 }
+
+func TestCnfFromNnf(t *testing.T) {
+	f := And(Or(And(Var("a"), Var("c"), Var("b"), Var("d")),
+		And(Or(Not(Var("a")), Not(Var("c"))), Or(Not(Var("b")),
+			Not(Var("d")))), Var("p")), Or(And(Or(Not(Var("a")),
+				Not(Var("c")), Not(Var("b")), Not(Var("d"))), Or(And(Var("a"),
+					Var("c")), And(Var("b"), Var("d")))), Not(Var("p"))), Var("p"),
+		Not(Var("c")), Var("d"))
+	model := Solve(f)
+	if model == nil {
+		t.Errorf("Failed to solve; f:\n%s", f)
+	}
+	check := f.Eval(model)
+	if !check {
+		t.Errorf("Model check failed")
+	}
+}


### PR DESCRIPTION
I encountered a situation where after constructing a formula with `bf`, the solver produced an invalid solution.  I tracked this down to a bug in the conversion from NNF to CNF in `cnfRec`, whereby constraints could get dropped in some cases.  I added a failing test and fixed it.  Unfortunately, I was not able to simplify the failing test formula further, but I suspect it is possible.

In addition to the above bug fix, I found another issue where the solver produces an invalid solution.  I added a failing test for it, but have not tracked down the cause.  I believe the formula in question is not satisfiable and `minisat` reports UNSAT given the DIMACS produced by gophersat. 