### PR TITLE
Refactor IntToLit

### DIFF
--- a/maxsat/parser.go
+++ b/maxsat/parser.go
@@ -99,7 +99,7 @@ func ParseWCNF(f io.Reader) (solver.Interface, error) {
 	}
 	relaxLits := make([]solver.Lit, relaxLit-nbVars-1)
 	for i := range relaxLits {
-		relaxLits[i] = solver.IntToLit(int32(nbVars + i + 1))
+		relaxLits[i] = solver.IntToLit(nbVars + i + 1)
 	}
 	prob := solver.ParseSlice(clauses)
 	prob.SetCostFunc(relaxLits, weights)

--- a/maxsat/problem.go
+++ b/maxsat/problem.go
@@ -56,7 +56,7 @@ func New(constrs ...Constr) *Problem {
 	optLits := make([]solver.Lit, 0, len(pb.blockWeights))
 	optWeights := make([]int, 0, len(pb.blockWeights))
 	for v, w := range pb.blockWeights {
-		optLits = append(optLits, solver.IntToLit(int32(v)))
+		optLits = append(optLits, solver.IntToLit(v))
 		optWeights = append(optWeights, w)
 	}
 	prob := solver.ParsePBConstrs(clauses)

--- a/solver/clause.go
+++ b/solver/clause.go
@@ -115,7 +115,7 @@ func (c *Clause) lbd() int {
 }
 
 func (c *Clause) setLbd(lbd int) {
-	c.lbdValue = (c.lbdValue & bothMasks) | uint32(lbd)
+	c.lbdValue = c.lbdValue&bothMasks | uint32(lbd)
 }
 
 func (c *Clause) incLbd() {

--- a/solver/parser.go
+++ b/solver/parser.go
@@ -21,7 +21,7 @@ func ParseSlice(cnf [][]int) *Problem {
 			if line[0] == 0 {
 				panic("null unit clause")
 			}
-			lit := IntToLit(int32(line[0]))
+			lit := IntToLit(line[0])
 			v := lit.Var()
 			if int(v) >= pb.NbVars {
 				pb.NbVars = int(v) + 1
@@ -33,7 +33,7 @@ func ParseSlice(cnf [][]int) *Problem {
 				if val == 0 {
 					panic("null literal in clause %q")
 				}
-				lits[j] = IntToLit(int32(val))
+				lits[j] = IntToLit(val)
 				if v := int(lits[j].Var()); v >= pb.NbVars {
 					pb.NbVars = v + 1
 				}
@@ -161,7 +161,7 @@ func ParseCNF(f io.Reader) (*Problem, error) {
 					if val > pb.NbVars || -val > pb.NbVars {
 						return nil, fmt.Errorf("invalid literal %d for problem with %d vars only", val, pb.NbVars)
 					}
-					lits = append(lits, IntToLit(int32(val)))
+					lits = append(lits, IntToLit(val))
 				}
 			}
 		}

--- a/solver/parser_pb.go
+++ b/solver/parser_pb.go
@@ -26,7 +26,7 @@ func ParseCardConstrs(constrs []CardConstr) *Problem {
 				if constr.Lits[i] == 0 {
 					panic("literal 0 found in clause")
 				}
-				lit := IntToLit(int32(constr.Lits[i]))
+				lit := IntToLit(constr.Lits[i])
 				v := lit.Var()
 				if int(v) >= pb.NbVars {
 					pb.NbVars = int(v) + 1
@@ -39,7 +39,7 @@ func ParseCardConstrs(constrs []CardConstr) *Problem {
 				if val == 0 {
 					panic("literal 0 found in clause")
 				}
-				lits[j] = IntToLit(int32(val))
+				lits[j] = IntToLit(val)
 				if v := int(lits[j].Var()); v >= pb.NbVars {
 					pb.NbVars = v + 1
 				}
@@ -68,7 +68,7 @@ func ParseCardConstrs(constrs []CardConstr) *Problem {
 func (pb *Problem) appendClause(constr PBConstr) {
 	lits := make([]Lit, len(constr.Lits))
 	for j, val := range constr.Lits {
-		lits[j] = IntToLit(int32(val))
+		lits[j] = IntToLit(val)
 	}
 	pb.Clauses = append(pb.Clauses, NewPBClause(lits, constr.Weights, constr.AtLeast))
 }
@@ -77,8 +77,8 @@ func (pb *Problem) appendClause(constr PBConstr) {
 func ParsePBConstrs(constrs []PBConstr) *Problem {
 	var pb Problem
 	for _, constr := range constrs {
-		for i := range constr.Lits {
-			lit := IntToLit(int32(constr.Lits[i]))
+		for _, l := range constr.Lits {
+			lit := IntToLit(l)
 			v := lit.Var()
 			if int(v) >= pb.NbVars {
 				pb.NbVars = int(v) + 1
@@ -95,7 +95,7 @@ func ParsePBConstrs(constrs []PBConstr) *Problem {
 		}
 		if sumW == card { // All lits must be true
 			for i := range constr.Lits {
-				lit := IntToLit(int32(constr.Lits[i]))
+				lit := IntToLit(constr.Lits[i])
 				found := false
 				for _, u := range pb.Units {
 					if u == lit {
@@ -137,7 +137,7 @@ func (pb *Problem) parsePBOptim(fields []string, line string) error {
 	}
 	pb.minLits = make([]Lit, len(lits))
 	for i, lit := range lits {
-		pb.minLits[i] = IntToLit(int32(lit))
+		pb.minLits[i] = IntToLit(lit)
 	}
 	pb.minWeights = weights
 	return nil
@@ -188,13 +188,13 @@ func (pb *Problem) parsePBConstrLine(fields []string, line string) error {
 		}
 		if sumW == card { // All lits must be true
 			for i := range constr.Lits {
-				lit := IntToLit(int32(constr.Lits[i]))
+				lit := IntToLit(constr.Lits[i])
 				pb.Units = append(pb.Units, lit)
 			}
 		} else {
 			lits := make([]Lit, len(constr.Lits))
 			for j, val := range constr.Lits {
-				lits[j] = IntToLit(int32(val))
+				lits[j] = IntToLit(val)
 			}
 			pb.Clauses = append(pb.Clauses, NewPBClause(lits, constr.Weights, card))
 		}

--- a/solver/pb.go
+++ b/solver/pb.go
@@ -23,7 +23,7 @@ func (c PBConstr) WeightSum() int {
 func (c PBConstr) Clause() *Clause {
 	lits := make([]Lit, len(c.Lits))
 	for i, val := range c.Lits {
-		lits[i] = IntToLit(int32(val))
+		lits[i] = IntToLit(val)
 	}
 	return NewPBClause(lits, c.Weights, c.AtLeast)
 }

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -343,7 +343,7 @@ func (s *Solver) propagateAndSearch(lit Lit, lvl decLevel) Status {
 				return Indet
 			}
 			if s.Stats.NbConflicts >= s.wl.idxReduce*s.wl.nbMax {
-				s.wl.idxReduce = (s.Stats.NbConflicts / s.wl.nbMax) + 1
+				s.wl.idxReduce = s.Stats.NbConflicts/s.wl.nbMax + 1
 				s.reduceLearned()
 				s.bumpNbMax()
 			}
@@ -577,9 +577,9 @@ func (s *Solver) decisionLits() []Lit {
 		if lvl := abs(s.model[i]); r == nil && lvl > 1 {
 			if s.model[i] < 0 {
 				// lvl-2 : levels beside unit clauses start at 2, not 0 or 1!
-				lits[lvl-2] = IntToLit(int32(i + 1))
+				lits[lvl-2] = IntToLit(i + 1)
 			} else {
-				lits[lvl-2] = IntToLit(int32(-i - 1))
+				lits[lvl-2] = IntToLit(-i - 1)
 			}
 		}
 	}
@@ -738,7 +738,7 @@ func (s *Solver) Optimal(results chan Result, stop chan struct{}) (res Result) {
 		copy(s.lastModel, s.model) // Save this model: it might be the last one
 		cost = 0
 		for i, lit := range s.minLits {
-			if (s.model[lit.Var()] > 0) == lit.IsPositive() {
+			if s.model[lit.Var()] > 0 == lit.IsPositive() {
 				if s.minWeights == nil {
 					cost++
 				} else {
@@ -803,7 +803,7 @@ func (s *Solver) Minimize() int {
 		copy(s.lastModel, s.model) // Save this model: it might be the last one
 		cost = 0
 		for i, lit := range s.minLits {
-			if (s.model[lit.Var()] > 0) == lit.IsPositive() {
+			if s.model[lit.Var()] > 0 == lit.IsPositive() {
 				if s.minWeights == nil {
 					cost++
 				} else {

--- a/solver/types.go
+++ b/solver/types.go
@@ -43,7 +43,7 @@ type Var int32
 type Lit int32
 
 // IntToLit converts a CNF literal to a Lit.
-func IntToLit(i int32) Lit {
+func IntToLit(i int) Lit {
 	if i < 0 {
 		return Lit(2*(-i-1) + 1)
 	}
@@ -76,7 +76,7 @@ func (l Lit) Var() Var {
 // Int returns the equivalent CNF literal.
 func (l Lit) Int() int32 {
 	sign := l&1 == 1
-	res := int32((l / 2) + 1)
+	res := int32(l/2 + 1)
 	if sign {
 		return -res
 	}


### PR DESCRIPTION
Noticed in passing that all callers of `IntToLit` seem to first cast `int` -> `int32` before calling the function. 