### PR TITLE
Fixing the error with MUS

### DIFF
--- a/explain/check.go
+++ b/explain/check.go
@@ -44,6 +44,7 @@ func (pb *Problem) UnsatChan(ch chan string) (valid bool, err error) {
 	defer pb.restore()
 	pb.initTagged()
 	for line := range ch {
+
 		fields := strings.Fields(line)
 		if len(fields) == 0 {
 			continue
@@ -66,7 +67,11 @@ func (pb *Problem) UnsatChan(ch chan string) (valid bool, err error) {
 		// Since clause is a logical consequence, append it to the problem
 		pb.Clauses = append(pb.Clauses, clause)
 	}
-	return false, nil
+
+	// If we did not send any information through the channel
+	// It implies that the problem is trivially unsatisfiable
+	// Since we had only unit clauses inside the channel.
+	return true, nil
 }
 
 // Unsat will parse a certificate, and return true iff the certificate is valid, i.e iff it makes the problem UNSAT

--- a/explain/mus_test.go
+++ b/explain/mus_test.go
@@ -1,0 +1,34 @@
+package explain
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func ExampleInstanceIsAMUS() {
+	const cnf = `p cnf 1 2
+	c This is a simple problem
+	1 0
+	-1 0`
+	pb, err := ParseCNF(strings.NewReader(cnf))
+	if err != nil {
+		fmt.Printf("could not parse problem: %v", err)
+		return
+	}
+	mus, err := pb.MUS()
+	if err != nil {
+		fmt.Printf("could not compute MUS: %v", err)
+		return
+	}
+	musCnf := mus.CNF()
+	// Sort clauses so as to always have the same output
+	lines := strings.Split(musCnf, "\n")
+	sort.Sort(sort.StringSlice(lines[1:]))
+	musCnf = strings.Join(lines, "\n")
+	fmt.Println(musCnf)
+	// Output:
+	// p cnf 1 2
+	// -1 0
+	// 1 0
+}


### PR DESCRIPTION
It appears that the MUS error comes from a "trivially unsatisfiable formula".
In such cases, the channel for the certification is empty since we made no decision.
So we should return true if we do not enter the loop through all the lines inside the channel.

Feel free to add more tests of trivially unsatisfiable formula before merging this PR.
