### PR TITLE
Fix extra slice growth in rebuildOrderHeap

### DIFF
--- a/solver/solver.go
+++ b/solver/solver.go
@@ -336,7 +336,7 @@ func backtrackData(c *Clause, model []decLevel) (btLevel decLevel, lit Lit) {
 }
 
 func (s *Solver) rebuildOrderHeap() {
-	ints := make([]int, s.nbVars)
+	ints := make([]int, 0, s.nbVars)
 	for v := 0; v < s.nbVars; v++ {
 		if s.model[v] == 0 {
 			ints = append(ints, int(v))


### PR DESCRIPTION
rebuildOrderHeap was allocing a slice with a len of the max required size, then
appending unbound vars to it. This resulted in a slice with nbVars entries of
'0' to start with, followed by the actual unbound vars. Adding those unbound
vars would cause slice growth.

Ultimately, all but the last leading `0` value would be ignored by the queue,
and maybe that shouldn't have been there, as that var might already have been
bound?

Replace the slice alloc `len` form with the `cap` form, so there's no leading
'0's, and append doesn't cause slice growth.
