### PR TITLE
Fix NNF of empty conjunction and disjunction.

### DIFF
--- a/bf/bf.go
+++ b/bf/bf.go
@@ -216,7 +216,7 @@ func (a and) nnf() Formula {
 		return res[0]
 	}
 	if len(res) == 0 {
-		return False
+		return True
 	}
 	return res
 }
@@ -268,7 +268,7 @@ func (o or) nnf() Formula {
 		return res[0]
 	}
 	if len(res) == 0 {
-		return True
+		return False
 	}
 	return res
 }

--- a/bf/bf_test.go
+++ b/bf/bf_test.go
@@ -40,6 +40,38 @@ func TestEmptyOr(t *testing.T) {
 	}
 }
 
+func TestNNF(t *testing.T) {
+	tests := []struct {
+		raw  Formula
+		want bool
+	}{
+		{
+			raw:  And(True, True, True),
+			want: true,
+		},
+		{
+			raw:  And(True, False, True),
+			want: false,
+		},
+		{
+			raw:  Or(False, False, False),
+			want: false,
+		},
+		{
+			raw:  Or(False, True, False),
+			want: true,
+		},
+	}
+	m := map[string]bool{}
+
+	for _, test := range tests {
+		f := test.raw.nnf()
+		if got, want := f.Eval(m), test.want; got != want {
+			t.Errorf("%s.nnf().Eval() = %t, want %t", test.raw, got, want)
+		}
+	}
+}
+
 func TestCNF(t *testing.T) {
 	f := And(Or(Var("a"), Var("b")), Var("i"), Or(Var("g"), Var("h"), And(Var("c"), Or(Var("d"), Var("e")), Var("f"))))
 	model := Solve(f)


### PR DESCRIPTION
In the existing code, and(True).Eval() = true, but and(True).nnf().Eval() = false. The nnf method elides True, leaving an
empty conjunction. So the problem is the choice of False for the NNF of empty conjunction. The dual bug existed for disjunction.