### PR TITLE
Make maxsat Solve return the broken constraints, if any were broken

### DIFF
--- a/maxsat/hardsoft_test.go
+++ b/maxsat/hardsoft_test.go
@@ -51,8 +51,9 @@ func TestBugInfiniteLoop(t *testing.T) {
 	}
 	problem := New(clauses...)
 
-	model, cost := problem.Solve()
+	model, cost, broken := problem.Solve()
 	fmt.Println(cost)
 	fmt.Println(model)
+	fmt.Println(broken)
 
 }


### PR DESCRIPTION
For a project I'm working on, I need the maxsat Solve method to return the indices of all constraints that had to be broken to solve the problem. I think this might be useful for other users as well, which is why I'm opening this pull request.
Please let me know if you want me to change something or if this is something you simply don't want in Gophersat. We can internally keep using our own fork, so I'm fine either way.